### PR TITLE
Added css for when the field appears in the admin sidebar

### DIFF
--- a/css/input.css
+++ b/css/input.css
@@ -73,3 +73,8 @@
 .button-link-switch-checkbox:checked + .button-link-switch-label:before {
     right: 0px;
 }
+
+#side-sortables .acf-smart-button-fields td {
+    width: 100%;
+    float: left;
+}


### PR DESCRIPTION
Allow for smart button to appear in wordpress admin sidebar

Before:
<img width="343" alt="screen shot 2016-03-25 at 23 06 23" src="https://cloud.githubusercontent.com/assets/1636310/14055976/49677314-f2de-11e5-8b6f-a883e6881267.png">

After:
<img width="312" alt="screen shot 2016-03-25 at 22 33 16" src="https://cloud.githubusercontent.com/assets/1636310/14055479/502de51a-f2da-11e5-8127-c74b49ab09d0.png">
