### PR TITLE
[Update] Added post type filter to field options

### DIFF
--- a/acf-smart-button-v5.php
+++ b/acf-smart-button-v5.php
@@ -94,6 +94,18 @@ class acf_field_smart_button extends acf_field {
 
 		$field = array_merge($this->defaults, $field);
 
+		acf_render_field_setting( $field, array(
+			'label'			=> __('Filter by Post Type','acf'),
+			'instructions'	=> '',
+			'type'			=> 'select',
+			'name'			=> 'post_type',
+			'choices'		=> acf_get_pretty_post_types(),
+			'multiple'		=> 1,
+			'ui'			=> 1,
+			'allow_null'	=> 1,
+			'placeholder'	=> __("All post types",'acf'),
+		));
+
 	}
 
 


### PR DESCRIPTION
This addition allows you to customise which post types are selectable through the 'internal link' dropdown.

This example just has media available:

<img width="941" alt="screen shot 2016-06-10 at 09 37 26" src="https://cloud.githubusercontent.com/assets/1636310/15958704/ff1d14e2-2eee-11e6-931a-beeeb5f13e6f.png">
