### PR TITLE
Fix for broken Internal Link field

### DIFF
--- a/acf-smart-button.php
+++ b/acf-smart-button.php
@@ -3,7 +3,7 @@
 	Plugin Name: Advanced Custom Fields: Smart Button
 	Plugin URI: https://github.com/gillesgoetsch/acf-smart-button
 	Description: A button field that lets you choose between internal and external and gives you either a post_object or a url field
-	Version: 1.0.4
+	Version: 1.0.5
 	Author: Gilles Goetsch
 	Author URI: https://gillesgoetsch.ch
 	License: GPLv2 or later
@@ -20,7 +20,7 @@
  *  @since	1.0.0
  */
 function acf_smart_button_load_textdomain() {
-  load_plugin_textdomain( 'acf-smart-button', false, dirname( plugin_basename(__FILE__) ) . '/lang/' );
+	load_plugin_textdomain( 'acf-smart-button', false, dirname( plugin_basename(__FILE__) ) . '/lang/' );
 }
 add_action( 'init', 'acf_smart_button_load_textdomain' );
 
@@ -35,6 +35,104 @@ function include_field_types_smart_button( $version ) {
 	include_once('acf-smart-button-v5.php');
 }
 add_action('acf/include_field_types', 'include_field_types_smart_button');
+
+
+/*
+* Register a new REST route for fetching posts of multiple post types in one go
+*
+* @type	action
+*/
+function register_multi_post_type_rest_route() {
+	register_rest_route('acf-smart-button/v1', '/posts', array(
+		'methods' => 'GET',
+		'callback' => 'get_multi_post_type_posts',
+    'permission_callback' => 'rest_route_permission_callback',
+		'args' => array(
+			'post_types' => array(
+				'description' => 'Array of post types to query.',
+				'type' => 'array',
+				'items' => array(
+					'type' => 'string',
+				),
+			),
+      'post_status' => array(
+        'description' => 'Array of post statuses to query.',
+        'type' => 'array',
+        'items' => array(
+          'type' => 'string',
+        ),
+      ),
+			'posts_per_page' => array(
+				'description' => 'Number of posts to return per page.',
+				'type' => 'integer',
+				'default' => 10,
+			),
+			'orderby' => array(
+				'description' => 'Field to order posts by.',
+				'type' => 'string',
+				'default' => 'date',
+			),
+			'order' => array(
+				'description' => 'Order of results (ASC or DESC).',
+				'type' => 'string',
+				'default' => 'DESC',
+			),
+      'q' => array(
+				'description' => 'Search Query',
+				'type' => 'string',
+				'default' => '',
+			),
+		),
+	));
+}
+
+/*
+* Permission callback for the REST route
+* Only allow access to users who have permission to edit posts
+*
+* @type	filter
+*/
+function rest_route_permission_callback() {
+  return current_user_can('edit_posts');
+}
+
+/*
+* Callback function for the REST route
+* Fetches posts of multiple post types using the get_posts function, and runs them through
+* the ACF post_object field filters to ensure compatibility with ACF fields that use post_object
+*
+* @type	function
+*/
+function get_multi_post_type_posts($request) {
+
+	// Set default or requested post types
+	$post_types = $request->get_param('post_types') ?: array('post', 'page');
+
+	// Build arguments array for get_posts
+	$args = array(
+		'post_type'      => $post_types,
+    'post_status'    => $request->get_param('post_status') ?: array('publish'),
+		'posts_per_page' => $request->get_param('posts_per_page') ?: 10,
+		'orderby'        => $request->get_param('orderby') ?: 'date',
+		'order'          => $request->get_param('order') ?: 'DESC',
+    's'              => $request->get_param('q') ?: '',
+		'suppress_filters' => false, // Allow filters to run
+	);
+
+  $args = apply_filters('acf/fields/post_object/query', $args, [], "");
+
+  $posts = get_posts($args);
+
+  $posts_filtered = array_map(function($post) {
+    return array(
+      'id' => $post->ID,
+      'title' => apply_filters('acf/fields/post_object/result', $post->post_title, $post, [], ""),
+    );
+  }, $posts);
+
+	return rest_ensure_response($posts_filtered);
+}
+add_action('rest_api_init', 'register_multi_post_type_rest_route');
 
 
 ?>

--- a/composer.json
+++ b/composer.json
@@ -10,6 +10,6 @@
   }],
   "type": "wordpress-plugin",
   "require": {
-    "php": ">=5.3.2"
+    "php": ">=7.4.0"
   }
 }

--- a/css/input.css
+++ b/css/input.css
@@ -25,6 +25,7 @@
 
 .acf-smart-button-fields .acf-field-post-object, .acf-smart-button-fields input.external {
   min-width: 200px;
+  max-width: 350px;
   padding-left: 25px;
   margin: 0;
 }
@@ -45,6 +46,7 @@
 
 .acf-smart-button-fields td {
   padding-right: 10px;
+  width: 33%;
 }
 
 .button-link-switch-text {

--- a/js/input.js
+++ b/js/input.js
@@ -6,7 +6,8 @@
     var $checkbox = $el.find('.button-link-switch-checkbox'),
       $internal = $el.find('.internal'),
       $external = $el.find('.external'),
-      $switcherLabels = $el.find('.switcher-container label');
+      $switcherLabels = $el.find('.switcher-container label'),
+      $internalSelect = $internal.find('select');
 
     // listen to checkbox change
     $checkbox.change(function() {
@@ -21,6 +22,36 @@
     // trigger change function on init to respect current state (do not trigger change event as this provokes browser alert on window close)
     helperCheckboxChange($checkbox, $internal, $external);
 
+    // Initialize select2 on the manually created select field for internal links
+    intitializeInternalSelect($internalSelect);
+  }
+
+  function intitializeInternalSelect($internalSelect) {
+
+    const queryString = $internalSelect.data('querystring')
+    const API_URL = '/wp-json/acf-smart-button/v1/posts/?'
+    const wp_nonce = $internalSelect.data('nonce')
+
+    $internalSelect.select2({
+      ajax: {
+        url: API_URL + queryString,
+        dataType: 'json',
+        headers: {
+          'X-WP-Nonce': wp_nonce
+        },
+        processResults: function (data) {
+          return {
+            results: data.map(function (item) {
+              console.log(item.title);
+              return {
+                id: item.id,
+                text: $('<span>'+item.title+'</span>').text(),
+              }
+            }
+          )};
+        }
+      }
+    });
   }
 
   function helperCheckboxChange($self, $internal, $external) {


### PR DESCRIPTION
The internal link field was failing to populate on several sites I manage. Looks like ACF changed some logic around nonces, and it broke the way acf-smart-button was using the acf/render_field action the "unofficial" internal link subfield. 

I've written a different way to fetch the post data and render the field manually, instead of using the ACF action, to work around the issue.